### PR TITLE
Ensuring that if there is an error in any step of the Kronos To Shifts sync, the sync is resilient enough to complete

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TeamsController.cs
@@ -359,7 +359,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
 
                         break;
 
-                        // The code below handles the system declined request.
+                    // The code below handles the system declined request.
                     default:
                         {
                             var integrationResponse = new ShiftsIntegResponse();
@@ -442,7 +442,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
                     // Manager has approved the request in Kronos.
                     else if (requestState == ApiConstants.ShiftsApproved && requestAssignedTo == ApiConstants.ShiftsManager)
                     {
-                       responseModelList = await this.ProcessSwapShiftRequestApprovalAsync(jsonModel, aadGroupId).ConfigureAwait(false);
+                        responseModelList = await this.ProcessSwapShiftRequestApprovalAsync(jsonModel, aadGroupId).ConfigureAwait(false);
                     }
 
                     // There is a System decline with the Swap Shift Request
@@ -580,12 +580,16 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
             }
             catch (Exception ex)
             {
+                // Logging when the inner exception is not null - including the open shift request ID.
                 if (ex.InnerException != null)
                 {
                     this.telemetryClient.TrackTrace($"Shift mapping has failed for {finalOpenShiftRequest.Id}: " + ex.InnerException.ToString());
+                    this.telemetryClient.TrackException(ex.InnerException);
                 }
 
-                this.telemetryClient.TrackTrace($"Shift mapping has resulted in some type of error with the following: {ex.StackTrace.ToString(CultureInfo.InvariantCulture)}");
+                // Logging the exception regardless, and making sure to add the open shift request ID as well.
+                this.telemetryClient.TrackTrace($"Shift mapping has resulted in some type of error with the following: {ex.StackTrace.ToString(CultureInfo.InvariantCulture)}, happening with open shift request ID: {finalOpenShiftRequest.Id}");
+                this.telemetryClient.TrackException(ex);
 
                 throw;
             }

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TimeOffRequestsController.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Controllers/TimeOffRequestsController.cs
@@ -87,7 +87,7 @@ namespace Microsoft.Teams.Shifts.Integration.API.Controllers
         /// </summary>
         /// <param name="isRequestFromLogicApp">Checks if request is coming from logic app or portal.</param>
         /// <returns>A <see cref="Task"/> representing the asynchronous operation.</returns>
-        internal async Task ProcessTimeOffRequetsAsync(string isRequestFromLogicApp)
+        internal async Task ProcessTimeOffRequestsAsync(string isRequestFromLogicApp)
         {
             this.telemetryClient.TrackTrace($"{Resource.ProcessTimeOffRequetsAsync} starts at: {DateTime.UtcNow.ToString("O", CultureInfo.InvariantCulture)} for isRequestFromLogicApp: " + isRequestFromLogicApp);
 

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Resource.Designer.cs
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Resource.Designer.cs
@@ -61,15 +61,6 @@ namespace Microsoft.Teams.Shifts.Integration.API {
         }
         
         /// <summary>
-        ///   Looks up a localized string similar to The AAD Group Id (or the Team ID) is missing..
-        /// </summary>
-        public static string AadGroupIdIsMissing {
-            get {
-                return ResourceManager.GetString("AadGroupIdIsMissing", resourceCulture);
-            }
-        }
-        
-        /// <summary>
         ///   Looks up a localized string similar to AddSwapShiftApprovalAsync.
         /// </summary>
         public static string AddSwapShiftApprovalAsync {

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Resource.resx
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.API/Resource.resx
@@ -292,10 +292,6 @@
   <data name="InternalServerErrorMessage" xml:space="preserve">
     <value>Internal Server Occurred</value>
   </data>
-  <data name="AadGroupIdIsMissing" xml:space="preserve">
-    <value>The AAD Group Id (or the Team ID) is missing.</value>
-    <comment>The message that would be raised when the aadGroupId is null.</comment>
-  </data>
   <data name="GenericNotAbleToRetrieveDataMessage" xml:space="preserve">
     <value>{0} - Data cannot be retrieved at this time.</value>
     <comment>This message is a generic message that will be showing whenever data cannot be retrieved</comment>


### PR DESCRIPTION
@aosolis Please find below:

## Details
If any of the intermediate entity sync fail (ex: TimeOff sync) for any reason, it should exit smoothly and let pending entity sync to continue (ex: Shift sync).

## Fix
Adding the necessary logic to be able trigger the correct syncing of the entities. For example, ensure the order is correct (i.e. Open Shift Requests, Swap Shift Requests, Shifts – in that order; as well as TimeOff Reasons, TimeOff Sync – in that order). Also resolved typos from ProcessTimeOffRequetsAsync to ProcessTimeOffRequestsAsync. Fix is done in SyncKronosToShiftsController.cs

### Added Fixes
* Resolved some of your VSO PR comments here - removed the unnecessary comments - TeamsController.cs file
* Fixed the typo - TimeOffRequestsController.cs - changed the method name from ProcessTimeOffRequetsAsync to ProcessTimeOffRequestsAsync

## Test
Deployed latest build on Test environment and ensured that all syncs are working end to end, Arun had reported that Shifts did not sync in his environment, which we could repro, subsequently deployed this fix in Test environment and verified
