### PR TITLE
Update Bond.Charp package version

### DIFF
--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Encryption/Encryption_Multi_Framework.csproj
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Encryption/Encryption_Multi_Framework.csproj
@@ -26,7 +26,7 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="Bond.CSharp" Version="8.0.0" />
+    <PackageReference Include="Bond.CSharp" Version="9.0.3" />
     <PackageReference Include="Microsoft.CodeAnalysis.FxCopAnalyzers" Version="2.9.8">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>

--- a/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Microsoft.Teams.Shifts.Integration.Configuration.csproj
+++ b/Kronos-Shifts-Connector/Microsoft.Teams.Shifts.Integration/Microsoft.Teams.Shifts.Integration.Configuration/Microsoft.Teams.Shifts.Integration.Configuration.csproj
@@ -5,6 +5,11 @@
     <UserSecretsId>73370532-ec58-48a4-9ab9-6c91e655aa81</UserSecretsId>
     <NeutralLanguage>en-US</NeutralLanguage>
   </PropertyGroup>
+   
+  <PropertyGroup>
+    <ErrorOnDuplicatePublishOutputFiles>false</ErrorOnDuplicatePublishOutputFiles>
+  </PropertyGroup>
+   
   <ItemGroup>
     <Content Remove="stylecop.json" />
   </ItemGroup>


### PR DESCRIPTION
Update Bond.Charp package version to 9.0.3 to fix the Azure deployment failure issue as below:


gbc.exe: CreateDirectory "obj\\Release\\netstandard2.0": invalid argument (Cannot create a file when that file already exists.)
C:\home\.nuget\bond.csharp\8.0.0\build\Common.targets(161,5): error MSB3073: The command ""C:\home\.nuget\bond.csharp\8.0.0\build\..\\tools\gbc.exe" c# --import-dir="C:\home\.nuget\bond.csharp\8.0.0\build\..\\tools\inc"  --jobs=-2 --namespace=bond=Bond --output-dir="obj/Release/netstandard2.0/"  @"obj/Release/netstandard2.0/bonddefaultcodegen.in"" exited with code 1. [C:\home\site\repository\Kronos-Shifts-Connector\Microsoft.Teams.Shifts.Integration\Encryption\Encryption_Multi_Framework.csproj]
Failed exitCode=1, command=dotnet publish "C:\home\site\repository\Kronos-Shifts-Connector\Microsoft.Teams.Shifts.Integration\Microsoft.Teams.Shifts.Integration.Configuration\Microsoft.Teams.Shifts.Integration.Configuration.csproj" --output "C:\local\Temp\8d9f23d30041456" --configuration Release
An error has occurred during web site deployment.